### PR TITLE
Fixed emitting of web-link and document-link nodes.

### DIFF
--- a/docs/manual.scr
+++ b/docs/manual.scr
@@ -16,6 +16,10 @@ Below is the complete reference to the Scriba format.
 
 @image[src=tag.png]()
 
+Attribute/value pairs should be separated by white space.
+If the value contains white space, then it should be surrounded
+by double quotes.
+
 This is a begin/end block:
 
 @code[lang=scribe](@include[path=includes/begin-end.scr]())

--- a/t/emitter.lisp
+++ b/t/emitter.lisp
@@ -86,3 +86,30 @@ test
 test
 
 @end(section)"))
+
+(test web-link-1
+  (emit-identity "Visit @link[uri=https://www.google.com/](Google)."))
+
+(test web-link-2
+  (parse-equal "Visit @link[uri=\"https://www.google.com/\"](Google)."
+               ;; Note, emitter outputs uri without double quotes:
+               "Visit @link[uri=https://www.google.com/](Google)."))
+
+(test ref-link-1
+  (emit-identity "See the third @ref[id=data-table-3](table) for the data."))
+
+(test ref-link-2
+  (parse-equal "See the third @ref[id=\"data-table-3\"](table) for the data."
+               ;; Note, emitter outputs uri without double quotes:
+               "See the third @ref[id=data-table-3](table) for the data."))
+
+(test ref-link-3
+  (emit-identity "See the third @ref[doc=foo-bar,id=data-table-3](table) for the data."))
+
+(test ref-link-4
+  (parse-equal "See the third @ref[doc=foo-bar id=\"data-table-3\"](table) for the data."
+               ;; Note, emitter removes a space between attributes
+               "See the third @ref[doc=foo-bar id=data-table-3](table) for the data."))
+
+(test ref-link-5
+  (emit-identity "See the third @ref[id=\"foo-bar doc=data-table-3\"](table) for the data."))


### PR DESCRIPTION
Also, I've fixed a bug with multiple arguments rendering.

Now values having a space are surrounded by double quotes.
And before this fix there wasn't spaces between emitted arguments.