### PR TITLE
Fixed code blocks emitter for case when the language attribute is missing

### DIFF
--- a/src/emitter.lisp
+++ b/src/emitter.lisp
@@ -118,8 +118,12 @@
   (trivial-tag node stream))
 
 (defmethod emit ((node code-block) stream)
-  (with-block-tag (node stream :extra-attrs (list (cons "lang" (language node))))
-    (emit-children node stream)))
+  (let* ((lang (language node))
+         (extra-args (when (and lang
+                                (not (string= lang "")))
+                       (list (cons "lang" lang)))))
+    (with-block-tag (node stream :extra-attrs extra-args)
+      (emit-children node stream))))
 
 (defmethod emit ((node inline-quote) stream)
   (with-tag (node stream)

--- a/t/emitter.lisp
+++ b/t/emitter.lisp
@@ -46,6 +46,11 @@ para3
 test
 @end(code)"))
 
+(test code-block-2
+      (emit-identity "@begin(code)
+test
+@end(code)"))
+
 (test quotes
   (emit-identity "@q(test)")
   (emit-identity "@begin(quote)


### PR DESCRIPTION
Previously when lang was missing, code block was rendered like this:

```
@begin[lang=NIL](code)
some code
@end(code)
```

or

```
@begin[lang=](code)
some code
@end(code)
```

In the first case parser was reading this attribute as "NIL" string.
In the latter case parser just signaled an error.